### PR TITLE
Replace ReaScript API by reapy API

### DIFF
--- a/reapy/X-Raym_Minimal text input with tkinter reapy.pyw
+++ b/reapy/X-Raym_Minimal text input with tkinter reapy.pyw
@@ -1,13 +1,8 @@
-# import reapy
-from reapy import reascript_api as RPR
-
-# import os
-# import sys
-# sys.argv=["Main"]
+import reapy
 
 from tkinter import *
 
-#Quit the script
+# Quit the script
 def quit():
   global root
   root.destroy()
@@ -15,7 +10,7 @@ def quit():
 def callback():
     text = E1.get()
     quit()
-    RPR.ShowMessageBox( text, 'test', 1 )
+    reapy.show_message_box(text, title='test', mode='ok-cancel')
 
 root = Tk() # Init TK
 root.lift() # Stay on top


### PR DESCRIPTION
I replaced `RPR.ShowMessageBox(text, 'test', 1)` with  `reapy.show_message_box(text, title='test', mode='ok-cancel')`. This allows a simpler `import reapy` instead of `from reapy import reascript_api as RPR`, but also more expressive function arguments. I thought it was better for a template to show how the reapy API is simpler to use and more pythonic than the native ReaScript API.